### PR TITLE
Various implementation improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,20 @@
 bin=main
+obj=main.o vector.o
 
-all: main 
+CC=gcc
+CFLAGS=-std=c99 -g -O2 -Wall -pedantic
 
+all: $(bin)
 
-main: main.o vector.o ; gcc main.o vector.o -o $(bin)
-main.o: vector.h main.c ; gcc main.c -std=c99 -c
-vector.o: vector.h vector.c ; gcc -std=c99 vector.c -c
+$(bin): $(obj)
+	$(CC) -o $@ $^
+%.o: %.c
+	$(CC) -c $(CFLAGS) -o $@ $<
 
-clean: ; rm -f *.o $(bin)
+clean:
+	rm -f $(obj) $(bin)
 
-test: main ; @./main # run tests
+test: $(bin)
+	@./main # run tests
 
 .PHONY: test

--- a/vector.c
+++ b/vector.c
@@ -41,12 +41,8 @@ void vector_free(vector* v) {
 }
 
 void vector_resize (vector *v) {
-  int cap = (int)(v->capacity * VECTOR_GROWTH_RATE);
-  void *p = malloc(cap * v->unit);
-  memcpy(p, v->data, v->length * v->unit);
-  free(v->data);
-  v->data = p;
-  v->capacity = cap;
+  v->capacity = (int)(v->capacity * VECTOR_GROWTH_RATE);
+  v->data = realloc(v->data, v->unit * v->capacity);
 }
 
 void vector_push(vector *v, void *elem) {

--- a/vector.c
+++ b/vector.c
@@ -6,7 +6,6 @@
 typedef char byte_t;
 
 static vector *vector_create_real(size_t unit, unsigned long *cap) {
-
   vector *v = (vector*) malloc(sizeof(vector));
 
   if (v == NULL) return NULL;
@@ -51,7 +50,6 @@ void vector_resize (vector *v) {
 }
 
 void vector_push(vector *v, void *elem) {
-
   if (v->length == v->capacity) {
     vector_resize(v);
   }
@@ -82,7 +80,6 @@ void *vector_get(vector *v, int i) {
 }
 
 void vector_splice(vector *v, int i, int n) {
-
   int max;
   byte_t *start = (byte_t*)v->data + (v->unit * i);
 
@@ -96,7 +93,7 @@ void vector_splice(vector *v, int i, int n) {
 }
 
 vector *vector_slice (vector *v, int i, int n) {
-  vector *s = vector_create(v->unit);
+  vector *s = vector_create_with_capacity(v->unit, n);
   memcpy(s->data, (byte_t*)v->data + (i * v->unit), n*v->unit);
   s->length = n;
   return s;
@@ -115,6 +112,8 @@ vector *vector_filter(vector *v, int func (void *)) {
 
   int i, res;
 
+  // no *_with_capacity because we have no idea how big the resulting
+  // vector could end up.
   vector *filter = vector_create(v->unit);
 
   for (i = 0; i < v->length; i++) {
@@ -132,7 +131,7 @@ vector *vector_map(vector *v, size_t unit, void *func (void *)) {
   int i;
   void *res;
 
-  vector *map = vector_create(unit);
+  vector *map = vector_create_with_capacity(unit, v->capacity);
 
   for (i = 0; i < v->length; i++) {
     res = func((byte_t*)v->data + (i * v->unit));

--- a/vector.c
+++ b/vector.c
@@ -3,18 +3,35 @@
 
 #include "vector.h"
 
-vector *vector_create(int unit) {
+static vector *vector_create_real(int unit, unsigned long *cap) {
 
   vector *v = (vector*) malloc(sizeof(vector));
 
   if (v == NULL) return NULL;
 
-  v->data = malloc(unit*VECTOR_INITIAL_CAPACITY);
+  v->capacity = cap ? *cap : VECTOR_INITIAL_CAPACITY;
+  if (v->capacity < VECTOR_INITIAL_CAPACITY) {
+    v->capacity = VECTOR_INITIAL_CAPACITY;
+  }
   v->unit = unit;
   v->length = 0;
-  v->capacity = VECTOR_INITIAL_CAPACITY;
+
+  v->data = calloc(v->capacity, v->unit);
+
+  if (v->data == NULL) {
+    free(v);
+    return NULL;
+  }
 
   return v;
+}
+
+vector *vector_create(int unit) {
+  return vector_create_real(unit, NULL);
+}
+
+vector *vector_create_with_capacity(int unit, unsigned long cap) {
+  return vector_create_real(unit, &cap);
 }
 
 void vector_free(vector* v) {

--- a/vector.c
+++ b/vector.c
@@ -3,6 +3,8 @@
 
 #include "vector.h"
 
+typedef char byte_t;
+
 static vector *vector_create_real(size_t unit, unsigned long *cap) {
 
   vector *v = (vector*) malloc(sizeof(vector));
@@ -55,7 +57,7 @@ void vector_push(vector *v, void *elem) {
   }
 
   // copy over element
-  memcpy(v->data + (v->unit * v->length), elem, v->unit);
+  memcpy((byte_t*)v->data + (v->unit * v->length), elem, v->unit);
 
   v->length++; // increase length of vector
 }
@@ -69,20 +71,20 @@ void *vector_pop(vector* v) {
   v->length--;
 
   // return address of last element
-  return v->data + (v->unit * v->length);
+  return (byte_t*)v->data + (v->unit * v->length);
 }
 
 void *vector_get(vector *v, int i) {
   // i is out of range
   if  (i < 0 || i >= v->length) return NULL;
 
-  return v->data + (i * v->unit);
+  return (byte_t*)v->data + (i * v->unit);
 }
 
 void vector_splice(vector *v, int i, int n) {
 
   int max;
-  void *start = v->data + (v->unit * i);
+  byte_t *start = (byte_t*)v->data + (v->unit * i);
 
   // n should not exceed max
   max = v->length - i;
@@ -95,16 +97,16 @@ void vector_splice(vector *v, int i, int n) {
 
 vector *vector_slice (vector *v, int i, int n) {
   vector *s = vector_create(v->unit);
-  memcpy(s->data, v->data + (i * v->unit), n*v->unit);
+  memcpy(s->data, (byte_t*)v->data + (i * v->unit), n*v->unit);
   s->length = n;
   return s;
 }
 
 void vector_each(vector *v, void func (int, void *)) {
   int i;
-  void *p;
+  byte_t *p;
   for (i = 0; i < v->length; i++) {
-    p = v->data + (i * v->unit);
+    p = (byte_t*)v->data + (i * v->unit);
     func(i, p);
   }
 }
@@ -116,9 +118,9 @@ vector *vector_filter(vector *v, int func (void *)) {
   vector *filter = vector_create(v->unit);
 
   for (i = 0; i < v->length; i++) {
-    res = func(v->data + (i * v->unit));
+    res = func((byte_t*)v->data + (i * v->unit));
     if (res == 1) {
-      vector_push(filter, v->data + (i * v->unit));
+      vector_push(filter, (byte_t*)v->data + (i * v->unit));
     }
   }
 
@@ -133,7 +135,7 @@ vector *vector_map(vector *v, size_t unit, void *func (void *)) {
   vector *map = vector_create(unit);
 
   for (i = 0; i < v->length; i++) {
-    res = func(v->data + (i * v->unit));
+    res = func((byte_t*)v->data + (i * v->unit));
     vector_push(map, res);
     free(res);
   }

--- a/vector.c
+++ b/vector.c
@@ -3,7 +3,7 @@
 
 #include "vector.h"
 
-static vector *vector_create_real(int unit, unsigned long *cap) {
+static vector *vector_create_real(size_t unit, unsigned long *cap) {
 
   vector *v = (vector*) malloc(sizeof(vector));
 
@@ -26,11 +26,11 @@ static vector *vector_create_real(int unit, unsigned long *cap) {
   return v;
 }
 
-vector *vector_create(int unit) {
+vector *vector_create(size_t unit) {
   return vector_create_real(unit, NULL);
 }
 
-vector *vector_create_with_capacity(int unit, unsigned long cap) {
+vector *vector_create_with_capacity(size_t unit, unsigned long cap) {
   return vector_create_real(unit, &cap);
 }
 
@@ -125,7 +125,7 @@ vector *vector_filter(vector *v, int func (void *)) {
   return filter;
 }
 
-vector *vector_map(vector *v, int unit, void *func (void *)) {
+vector *vector_map(vector *v, size_t unit, void *func (void *)) {
 
   int i;
   void *res;

--- a/vector.h
+++ b/vector.h
@@ -1,21 +1,23 @@
 #ifndef VECTOR_H
 #define VECTOR_H
 
+#include <stddef.h>
+
 #define VECTOR_INITIAL_CAPACITY 64
 #define VECTOR_GROWTH_RATE 1.5
 
 typedef struct {
   void *data;   // pointer to data of vector
-  int unit;     // unit size of any element in vector
+  size_t unit;  // unit size of any element in vector
   unsigned long length;   // how many element are currently stored
   unsigned long capacity; // how many spaces of unit size are available
 } vector;
 
 // create a new vector
 #define vector_create_t(type) (vector_create(sizeof(type)))
-vector *vector_create(int unit);
+vector *vector_create(size_t unit);
 // create a new vecctor with the indicated capacity
-vector *vector_create_with_capacity(int unit, unsigned long cap);
+vector *vector_create_with_capacity(size_t unit, unsigned long cap);
 // free vector resources
 void vector_free(vector *v);
 
@@ -42,6 +44,6 @@ void vector_each(vector *v, void func (int, void *));
 vector *vector_filter(vector *v, int func (void *));
 // get a new vector mapped from v
 #define vector_map_t(type,v,func) (vector_map(v,sizeof(type),func))
-vector *vector_map(vector *v, int unit, void *func (void *));
+vector *vector_map(vector *v, size_t unit, void *func (void *));
 
 #endif

--- a/vector.h
+++ b/vector.h
@@ -14,6 +14,8 @@ typedef struct {
 // create a new vector
 #define vector_create_t(type) (vector_create(sizeof(type)))
 vector *vector_create(int unit);
+// create a new vecctor with the indicated capacity
+vector *vector_create_with_capacity(int unit, unsigned long cap);
 // free vector resources
 void vector_free(vector *v);
 


### PR DESCRIPTION
Kind of a grab bag of improvements:
- More "standard" C idioms, such as using `size_t` where a size is expected, using `realloc`, etc.
- Ability to create a vector using a given capacity value, and use of this feature internally for efficiency purposes.
- Makefile that builds with warnings and optimizations (and fixes for some warnings)

Potential improvements I spotted but neglected to make:
- Substitute `unsigned` for `int` in places expecting a non-negative value (such as lengths and indices).
- Extra opaque data pointer parameter to `vector_map` that is passed to the callback (essentially creating a closure). Significant API breakage so I omitted it, but nested functions are a GNU extension.
